### PR TITLE
Added support for netstandard1.3

### DIFF
--- a/SimpleBase.nuspec
+++ b/SimpleBase.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>SimpleBase</id>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
         <title>SimpleBase</title>
         <authors>Sedat Kapanoglu</authors>
         <owners>Sedat Kapanoglu</owners>
@@ -14,7 +14,9 @@
         <tags>base16 hexadecimal base32 base58 bitcoin ripple flickr crockford extended hex rfc4648</tags>
     </metadata>
     <files>
-        <file src="src\bin\Release\SimpleBase.dll" target="lib\net45\SimpleBase.dll" />
-        <file src="src\bin\Release\SimpleBase.pdb" target="lib\net45\SimpleBase.pdb" />
+        <file src="src\bin\Release\net45\SimpleBase.dll" target="lib\net45\SimpleBase.dll" />
+        <file src="src\bin\Release\net45\SimpleBase.pdb" target="lib\net45\SimpleBase.pdb" />
+        <file src="src\bin\Release\netstandard1.3\SimpleBase.dll" target="lib\netstandard1.3\SimpleBase.dll" />
+        <file src="src\bin\Release\netstandard1.3\SimpleBase.pdb" target="lib\netstandard1.3\SimpleBase.pdb" />
     </files>
 </package>

--- a/SimpleBase.sln
+++ b/SimpleBase.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26711.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleBase", "src\SimpleBase.csproj", "{A9C1CF86-32B3-40E6-A51A-3E6D17C15EE3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleBase", "src\SimpleBase.csproj", "{A9C1CF86-32B3-40E6-A51A-3E6D17C15EE3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleBaseTest", "test\SimpleBaseTest.csproj", "{617BA86D-31E2-41EA-A1C8-E37602D58C07}"
 EndProject
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
 		.travis.yml = .travis.yml
+		appveyor.yml = appveyor.yml
 		LICENSE.txt = LICENSE.txt
 		README.md = README.md
 		SimpleBase.nuspec = SimpleBase.nuspec

--- a/SimpleBase.sln
+++ b/SimpleBase.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.26711.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleBase", "src\SimpleBase.csproj", "{A9C1CF86-32B3-40E6-A51A-3E6D17C15EE3}"
 EndProject
@@ -39,5 +39,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4816E756-0FA5-40C5-9CCC-C9BD3C93FC1C}
 	EndGlobalSection
 EndGlobal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,9 @@
+image: Visual Studio 2017
+before_build:
+- cmd: >-
+    appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+
+    nuget restore
+build:
+  parallel: true
+  verbosity: normal

--- a/src/SimpleBase.csproj
+++ b/src/SimpleBase.csproj
@@ -1,63 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{A9C1CF86-32B3-40E6-A51A-3E6D17C15EE3}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>SimpleBase</RootNamespace>
-    <AssemblyName>SimpleBase</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Numerics" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Base16.cs" />
-    <Compile Include="Base32.cs" />
-    <Compile Include="Base32Alphabet.cs" />
-    <Compile Include="Base58.cs" />
-    <Compile Include="Base58Alphabet.cs" />
-    <Compile Include="CrockfordBase32Alphabet.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Require.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+
+	<PropertyGroup>
+		<TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+		<RootNamespace>SimpleBase</RootNamespace>
+		<AssemblyName>SimpleBase</AssemblyName>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="System.Runtime.Numerics">
+			<Version>4.3.0</Version>
+		</PackageReference>
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
Converted the "SimpleBase.csproj" for .NET Core projects to
use the _TargetFrameworks_ feature to build a multi-targetted nuget package.
**Must be build with VS2017+**