### PR TITLE
Correct minor documentation comment typo in Base85

### DIFF
--- a/src/Base85.cs
+++ b/src/Base85.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 namespace SimpleBase
 {
     /// <summary>
-    /// Base58 encoding/decoding class.
+    /// Base85 encoding/decoding class.
     /// </summary>
     public sealed class Base85 : IBaseEncoder, IBaseStreamEncoder, INonAllocatingBaseEncoder
     {


### PR DESCRIPTION
This fixes a very minor typo in the [XMLDoc](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/) comment for the Base85 class. The class is erroneously referred to as "Base58 encoding/decoding class".