### PR TITLE
Reduce heap allocations when encoding

### DIFF
--- a/benchmark/EncoderBenchmarks.cs
+++ b/benchmark/EncoderBenchmarks.cs
@@ -5,6 +5,7 @@ using SimpleBase;
 namespace benchmark;
 
 [MarkdownExporterAttribute.GitHub]
+[MemoryDiagnoser]
 public class EncoderBenchmarks
 {
     private readonly byte[] buffer = new byte[64];

--- a/src/Base16.cs
+++ b/src/Base16.cs
@@ -213,7 +213,8 @@ public sealed class Base16(Base16Alphabet alphabet) : IBaseCoder, IBaseStreamCod
             return string.Empty;
         }
 
-        Span<char> output = new char[GetSafeCharCountForEncoding(bytes)];
+        int outputLen = GetSafeCharCountForEncoding(bytes);
+        Span<char> output = outputLen < 1024 ? stackalloc char[outputLen] : new char[outputLen];
         internalEncode(bytes, output, Alphabet.Value);
         return new string(output);
     }

--- a/src/Base32.cs
+++ b/src/Base32.cs
@@ -211,7 +211,7 @@ public sealed class Base32 : IBaseCoder, IBaseStreamCoder, INonAllocatingBaseCod
         // we are ok with slightly larger buffer since the output string will always
         // have the exact length of the output produced.
         int outputLen = GetSafeCharCountForEncoding(bytes);
-        Span<char> output = new char[outputLen];
+        Span<char> output = outputLen < 1024 ? stackalloc char[outputLen] : new char[outputLen];
         if (!internalEncode(
             bytes,
             output,

--- a/src/Base58.cs
+++ b/src/Base58.cs
@@ -224,7 +224,7 @@ public sealed class Base58(Base58Alphabet alphabet) : IBaseCoder, INonAllocating
 
         int numZeroes = getZeroCount(bytes);
         int outputLen = getSafeCharCountForEncoding(bytes.Length, numZeroes);
-        Span<char> output = new char[outputLen];
+        Span<char> output = outputLen < 1024 ? stackalloc char[outputLen] : new char[outputLen];
 
         return internalEncode(bytes, output, numZeroes, out int numCharsWritten)
             ? new string(output[..numCharsWritten])

--- a/src/Base85.cs
+++ b/src/Base85.cs
@@ -76,7 +76,7 @@ public class Base85(Base85Alphabet alphabet) : IBaseCoder, IBaseStreamCoder, INo
         }
 
         int outputLen = GetSafeCharCountForEncoding(bytes);
-        char[] output = new char[outputLen];
+        Span<char> output = outputLen < 1024 ? stackalloc char[outputLen] : new char[outputLen];
 
         return internalEncode(bytes, output, out int numCharsWritten)
             ? new string(output[..numCharsWritten])

--- a/src/Base85Ipv6.cs
+++ b/src/Base85Ipv6.cs
@@ -51,7 +51,7 @@ public class Base85Ipv6(Base85Alphabet alphabet) : Base85(alphabet)
         }
 
         var num = new BigInteger(buffer, isUnsigned: true, isBigEndian: true);
-        Span<char> str = new char[Base85Ipv6.ipv6chars];
+        Span<char> str = stackalloc char[Base85Ipv6.ipv6chars];
         for (int n = 0, o = ipv6chars - 1; n < ipv6chars; n++, o--)
         {
             num = BigInteger.DivRem(num, divisor, out var remainder);


### PR DESCRIPTION
Reduce heap allocations, that needs to be garbage collected, when encoding.
Using [stack allocations](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/stackalloc) instead, when it makes sense.

I have readded `MemoryDiagnoser` (no longer default) to encoder benchmarks to see reduced allocations & GC, besides wallclock performance.

**Before:**

| Method                                 | Mean      | Error    | StdDev    | Median    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|--------------------------------------- |----------:|---------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
| DotNet_Base64                          |  39.58 ns | 0.824 ns |  0.980 ns |  39.29 ns |  1.00 |    0.03 | 0.0318 |     200 B |        1.00 |
| SimpleBase_Base16_UpperCase            | 120.72 ns | 1.808 ns |  1.510 ns | 120.98 ns |  3.05 |    0.08 | 0.0892 |     560 B |        2.80 |
| SimpleBase_Base32_CrockfordWithPadding | 202.62 ns | 4.096 ns | 10.498 ns | 208.17 ns |  5.12 |    0.29 | 0.0739 |     464 B |        2.32 |
| SimpleBase_Base85_Z85                  | 230.25 ns | 4.599 ns |  9.078 ns | 231.50 ns |  5.82 |    0.27 | 0.0892 |     560 B |        2.80 |
| SimpleBase_Base58_Bitcoin              |  62.06 ns | 1.289 ns |  1.266 ns |  62.06 ns |  1.57 |    0.05 | 0.0497 |     312 B |        1.56 |

**With stack allocations:**

| Method                                 | Mean      | Error    | StdDev    | Median    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|--------------------------------------- |----------:|---------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
| DotNet_Base64                          |  39.43 ns | 0.587 ns |  0.549 ns |  39.44 ns |  1.00 |    0.02 | 0.0318 |     200 B |        1.00 |
| SimpleBase_Base16_UpperCase            | 114.88 ns | 1.392 ns |  1.234 ns | 114.57 ns |  2.91 |    0.05 | 0.0446 |     280 B |        1.40 |
| SimpleBase_Base32_CrockfordWithPadding | 191.03 ns | 3.880 ns | 10.221 ns | 195.69 ns |  4.85 |    0.27 | 0.0370 |     232 B |        1.16 |
| SimpleBase_Base85_Z85                  | 199.14 ns | 4.072 ns | 11.944 ns | 199.54 ns |  5.05 |    0.31 | 0.0293 |     184 B |        0.92 |
| SimpleBase_Base58_Bitcoin              |  54.27 ns | 1.161 ns |  2.691 ns |  53.67 ns |  1.38 |    0.07 | 0.0242 |     152 B |        0.76 |

BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.3775)  
Intel Core i7-10750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores  
.NET SDK 8.0.408  
  [Host]     : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2  
  DefaultJob : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2