### PR TITLE
Avoid an array allocation in StreamHelper

### DIFF
--- a/benchmark/DecoderBenchmarks.cs
+++ b/benchmark/DecoderBenchmarks.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using BenchmarkDotNet.Attributes;
 using SimpleBase;
 
@@ -8,13 +9,31 @@ namespace benchmark;
 [MemoryDiagnoser]
 public class DecoderBenchmarks
 {
-    readonly string s = new('a', 80);
+    static readonly string s = new('a', 80);
+    static readonly MemoryStream memoryStream = new();
 
     [Benchmark]
     public byte[] DotNet_Base64() => Convert.FromBase64String(s);
 
     [Benchmark]
     public byte[] SimpleBase_Base16_UpperCase() => Base16.UpperCase.Decode(s);
+
+    /// <summary>
+    /// Created to be able to bench <c>StreamHelper</c>
+    /// The encoding does not matter for benching <c>StreamHelper</c>
+    /// Base16 is fastest, means less overhead for measuring <c>StreamHelper</c>
+    /// </summary>
+    /// <remarks>
+    /// [IterationSetup] or [IterationCleanup] attributes are not recommended for microbenchmarks, so setup & cleanup are part of the benchmark
+    /// https://benchmarkdotnet.org/articles/features/setup-and-cleanup.html#sample-introsetupcleanupiteration
+    /// </remarks>
+    [Benchmark]
+    public void SimpleBase_Base16_UpperCase_TextReader()
+    {
+        StringReader reader = new(s); // No need to dispose, less overhead, StringReader does not leak anything
+        Base16.UpperCase.Decode(reader, memoryStream);
+        memoryStream.Position = 0; // Reset output stream, so it does not grow forever, we do not need to read it
+    }
 
     [Benchmark]
     public byte[] SimpleBase_Base32_Crockford() => Base32.Crockford.Decode(s);

--- a/src/StreamHelper.cs
+++ b/src/StreamHelper.cs
@@ -72,7 +72,7 @@ static class StreamHelper
             }
 
             var result = decodeBufferFunc(buffer.AsMemory(0, bytesRead));
-            output.Write(result.ToArray(), 0, result.Length);
+            output.Write(result.Span);
         }
     }
 


### PR DESCRIPTION
Avoid an array allocation.
Added benchmark to be able to validate the improvement