### PR TITLE
Reduce heap allocations when decoding

### DIFF
--- a/src/Base58.cs
+++ b/src/Base58.cs
@@ -254,7 +254,7 @@ public sealed class Base58(Base58Alphabet alphabet) : IBaseCoder, INonAllocating
         char zeroChar = ZeroChar;
         int numZeroes = getPrefixCount(text, zeroChar);
         int outputLen = GetSafeByteCountForDecoding(text.Length, numZeroes);
-        byte[] output = new byte[outputLen];
+        Span<byte> output = outputLen < Bits.SafeStackMaxAllocSize ? stackalloc byte[outputLen] : new byte[outputLen];
         if (!internalDecode(
             text,
             output,
@@ -264,7 +264,7 @@ public sealed class Base58(Base58Alphabet alphabet) : IBaseCoder, INonAllocating
             throw new InvalidOperationException("Output buffer was too small while decoding Base58");
         }
 
-        return output[..numBytesWritten];
+        return output[..numBytesWritten].ToArray();
     }
 
     /// <inheritdoc/>

--- a/src/Base85.cs
+++ b/src/Base85.cs
@@ -156,9 +156,9 @@ public class Base85(Base85Alphabet alphabet) : IBaseCoder, IBaseStreamCoder, INo
 
         // allocate a larger buffer if we're using shortcuts
         int decodeBufferLen = getSafeByteCountForDecoding(text.Length, Alphabet.HasShortcut);
-        byte[] decodeBuffer = new byte[decodeBufferLen];
+        Span<byte> decodeBuffer = decodeBufferLen < Bits.SafeStackMaxAllocSize ? stackalloc byte[decodeBufferLen] : new byte[decodeBufferLen];
         return internalDecode(text, decodeBuffer, out int numBytesWritten)
-            ? decodeBuffer[..numBytesWritten]
+            ? decodeBuffer[..numBytesWritten].ToArray()
             : throw new InvalidOperationException("Internal error: pre-allocated insufficient output buffer size");
     }
 

--- a/src/MoneroBase58.cs
+++ b/src/MoneroBase58.cs
@@ -27,7 +27,7 @@ public sealed class MoneroBase58(Base58Alphabet alphabet) : IBaseCoder, INonAllo
     /// </summary>
     public MoneroBase58()
         : this(Base58Alphabet.Bitcoin)
-    {            
+    {
     }
 
     /// <summary>
@@ -95,7 +95,7 @@ public sealed class MoneroBase58(Base58Alphabet alphabet) : IBaseCoder, INonAllo
         }
 
         int outputLen = getSafeByteCountForDecoding(text.Length);
-        byte[] output = new byte[outputLen];
+        Span<byte> output = outputLen < Bits.SafeStackMaxAllocSize ? stackalloc byte[outputLen] : new byte[outputLen];
         if (!internalDecode(
             text,
             output,
@@ -104,7 +104,7 @@ public sealed class MoneroBase58(Base58Alphabet alphabet) : IBaseCoder, INonAllo
             throw new InvalidOperationException("Output buffer size was incorrect while decoding MoneroBase58");
         }
 
-        return output[..numBytesWritten];
+        return output[..numBytesWritten].ToArray();
     }
 
     /// <inheritdoc/>
@@ -247,7 +247,7 @@ public sealed class MoneroBase58(Base58Alphabet alphabet) : IBaseCoder, INonAllo
             int tempSize = encodedBlockSizes.AsSpan().IndexOf(remainingBuffer.Length);
             if (tempSize < 0)
             {
-                // invalid length for encoded remaining buffer 
+                // invalid length for encoded remaining buffer
                 return false;
             }
             temp[(blockSize - tempSize)..].CopyTo(output[numBytesWritten..]);


### PR DESCRIPTION
Reduce heap allocations when decoding Base58, MoneroBase58 & Base85

The `.ToArray()` does not add any new allocations, the return of the range indexer allocated a new array behind the scenes.

The Base58_Bitcoin shows an increased time, but I think it is due to me running it on a laptop, so it is probably within margin of error, if you run it on your desktop, it might be a more consistent result.

Before:
| Method                                 | Mean        | Error      | StdDev    | Gen0   | Allocated |
|--------------------------------------- |------------:|-----------:|----------:|-------:|----------:|
| DotNet_Base64                          |   123.09 ns |   2.401 ns |  2.466 ns | 0.0138 |      88 B |
| SimpleBase_Base16_UpperCase            |    73.07 ns |   1.508 ns |  2.114 ns | 0.0101 |      64 B |
| SimpleBase_Base32_Crockford            |   227.61 ns |   4.202 ns |  3.725 ns | 0.0126 |      80 B |
| SimpleBase_Base85_Z85                  |   365.33 ns |   7.332 ns | 19.948 ns | 0.0277 |     176 B |
| SimpleBase_Base58_Bitcoin              | 5,245.45 ns | 104.599 ns | 97.842 ns | 0.0229 |     176 B |
| SimpleBase_Base58_Monero               |   163.75 ns |   3.349 ns |  3.723 ns | 0.0279 |     176 B |

After:
| Method                                 | Mean        | Error      | StdDev     | Median      | Gen0   | Allocated |
|--------------------------------------- |------------:|-----------:|-----------:|------------:|-------:|----------:|
| DotNet_Base64                          |   124.99 ns |   2.412 ns |   2.477 ns |   125.07 ns | 0.0138 |      88 B |
| SimpleBase_Base16_UpperCase            |    75.07 ns |   1.638 ns |   4.777 ns |    74.65 ns | 0.0101 |      64 B |
| SimpleBase_Base32_Crockford            |   212.44 ns |   6.077 ns |  17.919 ns |   207.08 ns | 0.0126 |      80 B |
| SimpleBase_Base85_Z85                  |   348.13 ns |   7.000 ns |  13.487 ns |   345.18 ns | 0.0138 |      88 B |
| SimpleBase_Base58_Bitcoin              | 5,271.37 ns | 102.346 ns | 140.093 ns | 5,224.80 ns | 0.0076 |      88 B |
| SimpleBase_Base58_Monero               |   158.33 ns |   3.220 ns |   7.462 ns |   157.57 ns | 0.0138 |      88 B |