### PR TITLE
Only copy bytes when required, otherwise use ranges of the span

### DIFF
--- a/src/Base58.cs
+++ b/src/Base58.cs
@@ -253,13 +253,12 @@ public sealed class Base58(Base58Alphabet alphabet) : IBaseCoder, INonAllocating
             text,
             output,
             numZeroes,
-            out int bytesWrittenRangeStart,
-            out int bytesWrittenRangeEnd))
+            out Range bytesWritten))
         {
             throw new InvalidOperationException("Output buffer was too small while decoding Base58");
         }
 
-        return output[bytesWrittenRangeStart..bytesWrittenRangeEnd].ToArray();
+        return output[bytesWritten].ToArray();
     }
 
     /// <inheritdoc/>
@@ -283,11 +282,10 @@ public sealed class Base58(Base58Alphabet alphabet) : IBaseCoder, INonAllocating
             input,
             output,
             zeroCount,
-            out int bytesWrittenRangeStart,
-            out int bytesWrittenRangeEnd);
+            out Range bytesWritten);
 
-        output[bytesWrittenRangeStart..bytesWrittenRangeEnd].CopyTo(output);
-        numBytesWritten = bytesWrittenRangeEnd - bytesWrittenRangeStart;
+        output[bytesWritten].CopyTo(output);
+        numBytesWritten = bytesWritten.End.Value - bytesWritten.Start.Value;
         return result;
     }
 
@@ -432,13 +430,13 @@ public sealed class Base58(Base58Alphabet alphabet) : IBaseCoder, INonAllocating
         ReadOnlySpan<char> input,
         Span<byte> output,
         int numZeroes,
-        out int bytesWrittenRangeStart,
-        out int bytesWrittenRangeEnd)
+        out Range bytesWritten)
     {
         if (numZeroes == input.Length)
         {
-            bytesWrittenRangeStart = 0;
-            return decodeZeroes(output, numZeroes, out bytesWrittenRangeEnd);
+            bool result = decodeZeroes(output, numZeroes, out int numBytesWritten);
+            bytesWritten = Range.EndAt(numBytesWritten);
+            return result;
         }
 
         var table = Alphabet.ReverseLookupTable;
@@ -465,8 +463,7 @@ public sealed class Base58(Base58Alphabet alphabet) : IBaseCoder, INonAllocating
             }
         }
 
-        bytesWrittenRangeStart = min - numZeroes;
-        bytesWrittenRangeEnd  = output.Length;
+        bytesWritten = new Range(min - numZeroes, output.Length);
         return true;
     }
 }


### PR DESCRIPTION
There is no need to move data, when the range can be used to create the new array.  
This has a large benefit in the the bitcoin bench.  
There is now 2 `out` args, but refactoring it would require some changes.  
A single `Range` `out` param might be heap allocated, even though it is struct, haven't made sure. If it is not, it is probably same performance, as it is same size as 2 `int`s when calling, but more readable.

Before:
| Method                      | Mean        | Error     | StdDev    | Gen0   | Allocated |
|---------------------------- |------------:|----------:|----------:|-------:|----------:|
| DotNet_Base64               |   118.94 ns |  3.701 ns | 10.914 ns | 0.0138 |      88 B |
| SimpleBase_Base16_UpperCase |    66.82 ns |  1.252 ns |  1.392 ns | 0.0101 |      64 B |
| SimpleBase_Base32_Crockford |   183.77 ns |  2.309 ns |  1.803 ns | 0.0126 |      80 B |
| SimpleBase_Base85_Z85       |   315.33 ns |  2.041 ns |  1.809 ns | 0.0138 |      88 B |
| SimpleBase_Base58_Bitcoin   | 5,063.38 ns | 91.616 ns | 81.215 ns | 0.0076 |      88 B |
| SimpleBase_Base58_Monero    |   142.66 ns |  2.635 ns |  2.200 ns | 0.0138 |      88 B |

After:
| Method                      | Mean        | Error     | StdDev    | Median      | Gen0   | Allocated |
|---------------------------- |------------:|----------:|----------:|------------:|-------:|----------:|
| DotNet_Base64               |   110.62 ns |  2.397 ns |  7.066 ns |   105.11 ns | 0.0138 |      88 B |
| SimpleBase_Base16_UpperCase |    65.16 ns |  1.360 ns |  1.272 ns |    64.41 ns | 0.0101 |      64 B |
| SimpleBase_Base32_Crockford |   192.19 ns |  3.881 ns | 11.072 ns |   190.21 ns | 0.0126 |      80 B |
| SimpleBase_Base85_Z85       |   314.83 ns |  1.760 ns |  1.560 ns |   314.69 ns | 0.0138 |      88 B |
| SimpleBase_Base58_Bitcoin   | 3,992.01 ns | 24.962 ns | 19.489 ns | 3,995.32 ns | 0.0076 |      88 B |
| SimpleBase_Base58_Monero    |   141.86 ns |  2.917 ns |  3.242 ns |   140.81 ns | 0.0138 |      88 B |

Also use static methods on SHA256 to avoid using and disposing overhead